### PR TITLE
Handle keys with characters that also happen to be delimiters (also minor QoL improvement)

### DIFF
--- a/TuyaKeyExtractor/KeyExtract.cs
+++ b/TuyaKeyExtractor/KeyExtract.cs
@@ -16,8 +16,6 @@ namespace TuyaKeyExtractor
 	/// </summary>
 	public class KeyExtract
 	{
-		//   public string search;
-		static readonly char[] delimiterChars = new[] { ',', '.', ':' };
 
 		/// <summary>
 		/// Parse the given data file and extract keys from it.
@@ -43,8 +41,11 @@ namespace TuyaKeyExtractor
 				
 				// parse the 'string' subnodes of the parent node
 				foreach ( XmlNode node in map[0].ChildNodes) {
-					var attr = node.Attributes["name"];
+
+					// Make a description of the node for error messages.
 					string description = null;
+
+					var attr = node.Attributes["name"];
 					if ( attr != null ){
 						description=$"Node {node.Name} \"{attr.Value}\"";
 					} else {

--- a/TuyaKeyExtractor/Menu.cs
+++ b/TuyaKeyExtractor/Menu.cs
@@ -236,7 +236,11 @@ namespace TuyaKeyExtractor
 
 		public void ClearConsole ()
 		{
-			Console.Clear ();
+			try {
+				Console.Clear ();
+			} catch ( Exception e ) {
+				Console.WriteLine ( "Failed to clear console - " + e.Message );
+			}
 		}
 
 		public void UrlOpener ( string url )

--- a/TuyaKeyExtractor/TuyaKeyExtractor.csproj
+++ b/TuyaKeyExtractor/TuyaKeyExtractor.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConsoleTables" Version="2.4.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Address (my) situation in which a device's localKey contains a colon, comma, or dot in the middle.  Original code would report a truncated localKey.  The fix is to HTML-decode and JSON-deserialize the specifically-applicable strings.

Also handle the console handle being bad during debugging for quality of life.  Dunno if that's just a "me" problem or if this affects others.

Left debug prints commented-in, in case it helps explain what's going on.
